### PR TITLE
Update index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -157,7 +157,7 @@ async function installServerFor(InstanceIds) {
   }
 }
 
-const waitingCount = [];
+const waitingCount = [0];
 
 function isNeedExpand() {
   let lastExpandedAt = Math.max(...Array.from(serversPool.values()).map(i => i.createdAt));


### PR DESCRIPTION
看起来初始的 watingCount 中需要有个 0，否则第一次运行时，后面的 isNeedExpand 中的 minWatingCount 会得到 MAX_SAFE_INTEGER，从而导致每次重启时都会给创建一个评测机。